### PR TITLE
CA-322784 Fix varstored-guard logging is verbose

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: c
+sudo: required
+services:
+  - docker
+install:
+  - wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-docker.sh
+script:
+  - bash -ex .travis-docker.sh
+env:
+  global:
+    - PACKAGE="varstored-guard"
+    - PINS="varstored-guard:."
+    - BASE_REMOTE="https://github.com/xapi-project/xs-opam.git"
+  matrix:
+    - DISTRO="debian-9-ocaml-4.07"

--- a/src/dune
+++ b/src/dune
@@ -1,6 +1,7 @@
 (executable
  (name main)
  (libraries
+	cmdliner
 	cohttp-lwt 
 	message-switch-lwt
 	rpclib-lwt 

--- a/varstored-guard.opam
+++ b/varstored-guard.opam
@@ -1,0 +1,19 @@
+opam-version: "2.0"
+maintainer: "xen-api@lists.xen.org"
+authors: [ "xen-api@lists.xen.org" ]
+homepage: "https://github.com/xapi-project/varstored-guard"
+dev-repo: "git+https://github.com/xapi-project/varstored-guard.git"
+bug-reports: "https://github.com/xapi-project/varstored-guard"
+depends: [
+  "cmdliner"
+  "cohttp-lwt"
+  "message-switch-lwt"
+  "rpclib-lwt"
+  "xapi-idl"
+  "xen-api-client-lwt"
+]
+synopsis: "varstored-guard"
+description: ""
+url {
+  src: "https://github.com/xapi-project/varstored-guard/archive/master.tar.gz"
+}


### PR DESCRIPTION
Increase log level to info, but add command line
switch to allow us to change it to debug if
necessary.

Also log to Local5 (xensource.log) rather than
Daemon (daemon.log).

Signed-off-by: lippirk <ben.anson@citrix.com>