### PR TITLE
maintenance: remove bisect_ppx preprocessing

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -9,7 +9,7 @@
 	xapi-idl.varstore.deprivileged
 	xapi-idl.varstore.privileged
 	xen-api-client-lwt)
- (preprocess (pps ppx_deriving_rpc bisect_ppx -conditional)))
+ (preprocess (pps ppx_deriving_rpc)))
 
 (install
  (section sbin)


### PR DESCRIPTION
It can be added again once dune properly supports bisect_ppx.