### PR TITLE
CA-341597: Raise the open fd limit

### DIFF
--- a/varstored-guard.service
+++ b/varstored-guard.service
@@ -11,6 +11,7 @@ Environment=OCAMLRUNPARAM=b
 ExecStart=/usr/sbin/varstored-guard
 # Needed to ensure exceptions are logged when the program fails:
 StandardError=syslog
+LimitNOFILE=4096
 # restart but fail if more than 5 failures in 30s
 Restart=on-failure
 StartLimitBurst=5


### PR DESCRIPTION
Raise the open fd limit to 4096 since each UEFI VM requires one open
listening socket plus the occasional connected socket.

Signed-off-by: Ross Lagerwall <ross.lagerwall@citrix.com>