### PR TITLE
CA-364138 XSI-1217: fix FD leak, Unix.EMFILE

### DIFF
--- a/src/varstored_interface.ml
+++ b/src/varstored_interface.ml
@@ -152,10 +152,9 @@ let rec wait_for_file_to_appear path =
   Lwt_unix.yield () >>= fun () ->
   Lwt.try_bind (fun () ->
     Conduit_lwt_unix.connect ~ctx:Conduit_lwt_unix.default_ctx (`Unix_domain_socket (`File path)))
-    (fun (_, ic, _oc) ->
-       D.debug "Socket at %s works" path;
-       (* do not close both channels, or we get an EBADF *)
-       Lwt_io.close ic)
+    (fun (_, ic, oc) ->
+      D.debug "Socket at %s works" path ;
+      Lwt_io.close oc >>= fun () -> Lwt_io.close ic)
     (fun e ->
        D.debug "Waiting for file %s to appear (%s)" path (Printexc.to_string e);
        Lwt_unix.sleep 0.1 >>= fun () ->


### PR DESCRIPTION
Close both FDs.

This is a backport of 

* https://github.com/xapi-project/xen-api/commit/703b967b619ebee8a5483b70412d0e88c71e1173

in a different repository.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>